### PR TITLE
Fix Date.Format strings

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -15,11 +15,11 @@
 
     {{ if ( default true .Params.showDate ) }}
     <div class="float-md-right">
-      <span title="Lastmod: {{ .Lastmod.Format "2006-01-01" }}. Published at: {{ .PublishDate.Format "2006-01-01" }}.">
+      <span title="Lastmod: {{ .Lastmod.Format "2006-01-02" }}. Published at: {{ .PublishDate.Format "2006-01-02" }}.">
         {{ if ne .Lastmod .PublishDate }}
-          Lastmod: {{ dateFormat ( default "2006-01-01" .Site.Params.dateFormat ) .Lastmod }}
+          Lastmod: {{ dateFormat ( default "2006-01-02" .Site.Params.dateFormat ) .Lastmod }}
         {{ else }}
-          Published: {{ dateFormat "2006-01-01" .PublishDate }}
+          Published: {{ dateFormat "2006-01-02" .PublishDate }}
         {{ end }}
       </span>
     </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -17,7 +17,7 @@
         <h3>{{ .Title }}</h3>
       </a>
       <small>{{ .Permalink }}</small>
-      {{ .Date.Format "2006-01-01" }}
+      {{ .Date.Format "2006-01-02" }}
     </div>
     {{ .Summary }}
   </div>

--- a/layouts/partials/card.page.html
+++ b/layouts/partials/card.page.html
@@ -9,7 +9,7 @@
     <div class="Subhead-description">
       {{ partial "taxonomy.html" . }}
       <div class="float-md-right">
-        <span>{{ .Date.Format "2006-01-01" }}</span>
+        <span>{{ .Date.Format "2006-01-02" }}</span>
       </div>
     </div>
   </div>


### PR DESCRIPTION
The current Format strings make the dates appear as Year-Month-Month. This fix makes them appear correctly as Year-Month-Day.