### PR TITLE
Fix #15

### DIFF
--- a/static/assets/style.css
+++ b/static/assets/style.css
@@ -38,7 +38,7 @@ aside {
   top: 0;
   max-height: 100vh;
   display: block;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 /* Menu */


### PR DESCRIPTION
# Summary
In some OS, overflow-y: scroll; causes unintended scroll bar.
Changing this to auto fixes it.

fix #15 