### PR TITLE
Twitter card image use absolute path

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -36,7 +36,7 @@
     <meta name="twitter:creator" content="@{{ .Site.Params.Twitter }}">
     <meta name="twitter:title" content="{{ if .Title }}{{ .Title }} | {{ end }}{{ .Site.Title }}">
     <meta name="twitter:description" content="{{ .Description | default .Summary }}|{{ .Site.Params.Description }}">
-    <meta name="twitter:image" content="twitter-card.png">
+    <meta name="twitter:image" content="{{ .Site.BaseURL }}twitter-card.png">
     {{ end }}
 
 


### PR DESCRIPTION
`meta[name="twitter:image"]` requires web url.

test on
https://cards-dev.twitter.com/validator
