### PR TITLE
Update copyright to use config

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ shareTo = ["Twitter", "Hatena", "Facebook", "Pocket"]
 showFooterCredits = true
 ```
 
-That being said, below is all recommended configurations.
+That being said, below is all recommended configuration example.
 ```config.toml
 # config.toml
 
@@ -67,7 +67,7 @@ googleAnalytics = "U-12345678-0"
 
 # Enter a copyright notice to display in the site footer.
 # To display a copyright symbol, type `&copy;`.
-copyright = ""
+copyright = "&copy;Your Name 2019"
 
 [frontmatter]
 # update sitemap.xml's lastmod datetime by file change time, instead of git.

--- a/README.md
+++ b/README.md
@@ -38,11 +38,15 @@ hasCJKLanguage = true
 pygmentsCodeFences = true
 pygmentsUseClasses = true
 
+# Enter a copyright notice to display in the site footer.
+# To display a copyright symbol, type `&copy;`.
+copyright = ""
+
 [params]
 # Chose Social Sharing Buttons you want to use.
 shareTo = ["Twitter", "Hatena", "Facebook", "Pocket"]
 # You may disable copyright sentence by setting this to false.
-creditHugoPrimer = true
+showFooterCredits = true
 ```
 
 That being said, below is all recommended configurations.
@@ -61,6 +65,10 @@ pygmentsCodeFences = true
 pygmentsUseClasses = true
 googleAnalytics = "U-12345678-0"
 
+# Enter a copyright notice to display in the site footer.
+# To display a copyright symbol, type `&copy;`.
+copyright = ""
+
 [frontmatter]
 # update sitemap.xml's lastmod datetime by file change time, instead of git.
 lastmod = ["lastmod", ":fileModTime", ":default"]
@@ -73,7 +81,7 @@ useIcon = true
 useTwitterCard = true
 
 shareTo = ["Twitter", "Hatena", "Facebook", "Pocket"]
-creditHugoPrimer = true
+showFooterCredits = true
 ```
 
 #### archetypes/default.md

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -68,11 +68,7 @@
       </div>
 
       <div id="footer" class="pt-2 pb-3 bg-white text-center">
-        {{ if (default true .Site.Params.CreditHugoPrimer) }}
-          <span class="text-small text-gray">
-            {{ partial "copyright.html" . }}
-          </span>
-        {{ end }}
+        {{ partial "footer.html" . }}
       </div>
     </div>
 

--- a/layouts/partials/copyright.html
+++ b/layouts/partials/copyright.html
@@ -1,4 +1,4 @@
-©Qiushi Pan 2018.
-Generated with
-<a href="https://gohugo.io" class="link-gray-dark">Hugo</a> and
-<a href="https://github.com/qqhann/hugo-primer" class="link-gray-dark">Hugo-Primer</a> theme.
+{{ with .Site.Copyright }}{{ . | markdownify }} &middot; {{ end }}
+Powered by the
+<a href="https://github.com/qqhann/hugo-primer" class="link-gray-dark">Hugo-Primer</a> theme for
+<a href="https://gohugo.io" class="link-gray-dark">Hugo</a>.

--- a/layouts/partials/copyright.html
+++ b/layouts/partials/copyright.html
@@ -1,4 +1,0 @@
-{{ with .Site.Copyright }}{{ . | markdownify }} &middot; {{ end }}
-Powered by the
-<a href="https://github.com/qqhann/hugo-primer" class="link-gray-dark">Hugo-Primer</a> theme for
-<a href="https://gohugo.io" class="link-gray-dark">Hugo</a>.

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,0 +1,10 @@
+{{/* Credits and Copyright */}}
+{{ if (default true .Site.Params.ShowFooterCredits) }}
+  <span class="text-small text-gray">
+    {{ with .Site.Copyright }}{{ . | markdownify }} &middot; {{ end }}
+
+    Powered by the
+    <a href="https://github.com/qqhann/hugo-primer" class="link-gray-dark">Hugo-Primer</a> theme for
+    <a href="https://gohugo.io" class="link-gray-dark">Hugo</a>.
+  </span>
+{{ end }}


### PR DESCRIPTION
# Fix
Generally, it seems footer copyright should be the website author, instead of the theme author.

# Note
Add your copyright in `config.yaml`
```
# Enter a copyright notice to display in the site footer.
# To display a copyright symbol, type `&copy;`.
copyright = ""
```

---
closes #22 