### PR TITLE
Fix deprecation of .URL in Paginator in theme

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -13,7 +13,7 @@
   {{ range .Paginator.Pages }}
   <div>
     <div>
-      <a href="{{ .URL }}">
+      <a href="{{ .RelPermalink }}">
         <h3>{{ .Title }}</h3>
       </a>
       <small>{{ .Permalink }}</small>
@@ -28,19 +28,19 @@
     <div class="pagination">
       <ul>
         {{ if .Paginator.HasPrev }}
-        <a href="{{ .Paginator.Prev.URL }}" class="previous_page">Prev</a>
+        <a href="{{ .Paginator.Prev.RelPermalink }}" class="previous_page">Prev</a>
         {{ else }}
         <span class="previous_page disabled">Prev</span>
         {{ end }}
 
         {{ range .Paginator.Pagers }}
-          <a href="{{ .URL }}">
+          <a href="{{ .RelPermalink }}">
             {{ .PageNumber }}
           </a>
         {{ end }}
 
         {{ if .Paginator.HasNext }}
-        <a href="{{ .Paginator.Next.URL }}" class="next_page">Next</a>
+        <a href="{{ .Paginator.Next.RelPermalink }}" class="next_page">Next</a>
         {{ else }}
         <span class="next_page disabled">Next</span>
         {{ end }}

--- a/layouts/partials/card.page.html
+++ b/layouts/partials/card.page.html
@@ -2,7 +2,7 @@
 <div class="rounded-2 box-shadow-medium px-3 pb-2 pt-2 mb-3">
   <div class="Subhead mb-2">
     <div class="Subhead-heading">
-      <a href="{{ .URL }}">
+      <a href="{{ .RelPermalink }}">
         <div class="h2 mt-1 mb-1">{{ .Title }}</div>
       </a>
     </div>
@@ -16,6 +16,6 @@
   <div class="text-gray">
     <!-- summary -->
     {{ .Summary }}
-    <a class="muted-link" href="{{ .URL }}">…</a>
+    <a class="muted-link" href="{{ .RelPermalink }}">…</a>
   </div>
 </div>

--- a/layouts/partials/paginator.html
+++ b/layouts/partials/paginator.html
@@ -4,7 +4,7 @@
   <div class="pagination">
     <ul>
       {{ if $pag.HasPrev }}
-      <a href="{{ $pag.Prev.URL }}" class="previous_page">Prev</a>
+      <a href="{{ $pag.Prev.RelPermalink }}" class="previous_page">Prev</a>
       {{ else }}
       <span class="previous_page disabled">Prev</span>
       {{ end }}
@@ -24,7 +24,7 @@
             {{ if eq . $pag }}
               <em class="current selected" aria-current="true">{{ .PageNumber }}</em>
             {{ else }}
-              <a href="{{ .URL }}">{{ .PageNumber }}</a>
+              <a href="{{ .RelPermalink }}">{{ .PageNumber }}</a>
             {{ end }}
           {{ else if ($.Scratch.Get "__paginator.shouldEllipse") }}
             <span class="gap">…</span>
@@ -32,7 +32,7 @@
       {{ end }}
 
       {{ if $pag.HasNext }}
-      <a href="{{ $pag.Next.URL }}" class="next_page">Next</a>
+      <a href="{{ $pag.Next.RelPermalink }}" class="next_page">Next</a>
       {{ else }}
       <span class="next_page disabled">Next</span>
       {{ end }}

--- a/layouts/taxonomy/terms.html.html
+++ b/layouts/taxonomy/terms.html.html
@@ -14,16 +14,16 @@
   <div class="rounded-2 box-shadow-medium px-3 pb-2 pt-2 mb-2">
     <!-- single page card -->
     <div class="mb-2">
-      <a href="{{ .URL }}" class="link-gray-dark"><span class="h2">{{ .Title }}</span></a>
+      <a href="{{ .RelPermalink }}" class="link-gray-dark"><span class="h2">{{ .Title }}</span></a>
       <span class="text-right Counter Counter--gray">{{ len .Pages }}</span>
     </div>
     <div class="text-gray">
       {{ range first 5 .Pages }}
-      <a class="btn btn-transparent bg-blue-light link-gray mb-2" href="{{ .URL }}" role="button">{{ .Title }}</a>
+      <a class="btn btn-transparent bg-blue-light link-gray mb-2" href="{{ .RelPermalink }}" role="button">{{ .Title }}</a>
       {{ end }}
 
       {{ if gt (len .Pages) 5 }}
-      <a class="btn btn-transparent link-gray mb-2" href="{{ .URL }}" role="button">…more</a>
+      <a class="btn btn-transparent link-gray mb-2" href="{{ .RelPermalink }}" role="button">…more</a>
       {{ end }}
     </div>
   </div>


### PR DESCRIPTION
It looks like the pagination module in Hugo has deprecated the `.URL` directive, and thus you currently get warnings like this on the latest version:

> WARN 2019/09/30 21:04:09 Page's .URL is deprecated and will be removed in a future release. Use .Permalink or .RelPermalink. If what you want is the front matter URL value, use .Params.url.

I tested this out on my own site locally and verified that changing these references to `.RelPermalink` alleviates the warnings. I'm unsure of modifications to `card.page.html`, but all other files exist directly in `{{ range .Paginator.Pages }}` or similar blocks, which are directly relevant.

So, this PR should fix the deprecation warning generated by using `.URL` since it's deprecated.