### PR TITLE
add variable enableMathJax and fix a build error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ twitter = "your_twitter_id"
 # You can use favicon by addin them manually.
 useIcon = true
 useTwitterCard = true
+# Use MathJax.js. Disabling site-wide and you still can enable in indivisual pages
+math = true
 
 shareTo = ["Twitter", "Hatena", "Facebook", "Pocket"]
 showFooterCredits = true

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -72,10 +72,11 @@
       </div>
     </div>
 
-
+    {{ if .Site.Params.enableMathJax }}
     <!-- Scripts -->
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
     <!-- MathJax -->
     <script type="text/x-mathjax-config">MathJax.Hub.Config({ tex2jax: { inlineMath: [['$','$'], ['\\(','\\)']] } });</script>
+    {{ end }}
   </body>
 </html>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -72,7 +72,7 @@
       </div>
     </div>
 
-    {{ if .Site.Params.enableMathJax }}
+    {{ if or .Params.math ( default true .Site.Params.math ) }}
     <!-- Scripts -->
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
     <!-- MathJax -->

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -34,7 +34,7 @@
         {{ end }}
 
         {{ range .Paginator.Pagers }}
-          <a href="{{ .RelPermalink }}">
+          <a href="{{ .URL }}">
             {{ .PageNumber }}
           </a>
         {{ end }}


### PR DESCRIPTION
1. add variable enableMathJax

2. fix hugo build error:
execute of template failed: template: index.html:32:22: executing "main" at <.RelPermalink>: can't evaluate field RelPermalink in type *page.Pager.