### PR TITLE
Fix invalid variable in child menu

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -14,7 +14,7 @@
       <div class="Box Box--condensed position-absolute dropdown-content ">
         {{ range .Children }}
         <div class="Box-body" style="">
-          <a href="{{ .RelPermalink }}">
+          <a href="{{ .URL }}">
             {{ .Name }}
           </a>
         </div>


### PR DESCRIPTION
There is no `.RelPermalink` available for the menu:
https://gohugo.io/variables/menus/

Instead we need to use `.URL`