### PR TITLE
Feature: allow early script embedding

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -45,7 +45,8 @@
     <link rel="stylesheet" href="{{ `assets/syntax.css` | relURL }}">
     <link rel="stylesheet" href="{{ `assets/primer-build.css` | relURL }}">
     <link rel="stylesheet" href="{{ `assets/style.css` | relURL }}">
-    <link rel="stylesheet" href="{{ `assets/custom_style.css` | relURL }}">
+
+    {{ partial "custom_head_end.html" . }}
   </head>
 
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
+    {{ partial "custom_head_start.html" . }}
+
     {{ if not .Site.BuildDrafts }}
     {{ template "_internal/google_analytics_async.html" . }}
     {{ end }}

--- a/layouts/partials/custom_head_end.html
+++ b/layouts/partials/custom_head_end.html
@@ -1,0 +1,7 @@
+{{/* Custom HTML head tag contents go here if it needs to be the very last thing within the head.
+  This is useful for including stylesheets that need to override existing styles.
+
+  If you are upgrading from a previous version, just add the following line
+  to `layouts/partials/custom_head_end.html`:
+  <link rel="stylesheet" href="{{ `assets/custom_style.css` | relURL }}">
+*/}}

--- a/layouts/partials/custom_head_start.html
+++ b/layouts/partials/custom_head_start.html
@@ -1,0 +1,5 @@
+{{/* Custom HTML head tag contents go here if it needs to be the very first thing within the head.
+  This is useful for scripts such as the cookie consent script from Osano which needs to block other
+  scripts from setting cookies before the user viewer has given consent to do so. Another example might
+  be when you are trying to profile the page load you want the script to start recording as early as
+  possible. */}}

--- a/static/assets/custom_style.css
+++ b/static/assets/custom_style.css
@@ -1,1 +1,0 @@
-/* Override this file to add your own style adjustments */


### PR DESCRIPTION
There are two changes there. One to add an include at the top of the HTML `head` tag so that the user can include scripts that need to be the first thing loaded.

e.g. Osano or other cookie consent scripts which blocks the loading of other scripts until user consent has been given. This allows people to more easily comply with regulations in the EU.

This is just one example, but I'm sure there are many cases of scripts that should be loaded as early as possible.

The second change I made is just to make the previous inclusion of a custom stylesheets much more flexible and consistent with the change I made in the first commit.